### PR TITLE
linux: fix assert when failed to read /proc file

### DIFF
--- a/gdb/linux-tdep.c
+++ b/gdb/linux-tdep.c
@@ -2187,7 +2187,7 @@ linux_fill_prpsinfo (struct elf_internal_linux_prpsinfo *p)
   xsnprintf (filename, sizeof (filename), "/proc/%d/cmdline", (int) pid);
   /* The full name of the program which generated the corefile.  */
   gdb_byte *buf = NULL;
-  size_t buf_len = target_fileio_read_alloc (NULL, filename, &buf);
+  ssize_t buf_len = target_fileio_read_alloc (NULL, filename, &buf);
   gdb::unique_xmalloc_ptr<char> fname ((char *)buf);
 
   if (buf_len < 1 || fname.get ()[0] == '\0')


### PR DESCRIPTION
For bare metal debugging, read /proc returns negative number.

The size_t buf_len loses the sigh and make below judgment wrong   if (buf_len < 1 || fname.get ()[0] == '\0'), leading to assert because of the invalid fname.