### PR TITLE
riscv: fix judgement on target float feature

### DIFF
--- a/gdb/riscv-tdep.c
+++ b/gdb/riscv-tdep.c
@@ -4241,7 +4241,7 @@ riscv_gdbarch_init (struct gdbarch_info info,
   /* We do support running binaries compiled for 32-bit float on targets
      with 64-bit float, so we only complain if the binary requires more
      than the target has available.  */
-  if (abi_features.flen > features.flen)
+  if (features.flen != 0 && abi_features.flen > features.flen)
     error (_("bfd requires flen %d, but target has flen %d"),
 	    abi_features.flen, features.flen);
 


### PR DESCRIPTION
Only check if the float feature mismatch when target provides float feature description.

When target provides custom target description xml file that only includes core registers, we should not check if the float feature mismatch with binary.

When target doesn't provide the custom xml file, gdb works happily without knowing the FP registers. So this change should not introduce regression.