### PR TITLE
arm: support MSP, PSP register saved to coredump

### DIFF
--- a/bfd/elf-bfd.h
+++ b/bfd/elf-bfd.h
@@ -1673,7 +1673,7 @@ struct elf_backend_data
      Returns the value to be installed in the ST_SHNDX field of the
      emitted symbol.  If not defined, the value is left unchanged.  */
   unsigned int (*symbol_section_index) (bfd *, elf_symbol_type *);
-  
+
   /* Called when a section has extra reloc sections.  */
   bool (*init_secondary_reloc_section) (bfd *, Elf_Internal_Shdr *,
 					const char *, unsigned int);
@@ -2966,6 +2966,8 @@ extern char *elfcore_write_s390_gs_cb
 extern char *elfcore_write_s390_gs_bc
   (bfd *, char *, int *, const void *, int);
 extern char *elfcore_write_arm_vfp
+  (bfd *, char *, int *, const void *, int);
+extern char *elfcore_write_arm_m_system
   (bfd *, char *, int *, const void *, int);
 extern char *elfcore_write_aarch_tls
   (bfd *, char *, int *, const void *, int);

--- a/bfd/elf.c
+++ b/bfd/elf.c
@@ -10547,6 +10547,12 @@ elfcore_grok_arm_vfp (bfd *abfd, Elf_Internal_Note *note)
 }
 
 static bool
+elfcore_grok_arm_m_system (bfd *abfd, Elf_Internal_Note *note)
+{
+  return elfcore_make_note_pseudosection (abfd, ".reg-arm-m-system", note);
+}
+
+static bool
 elfcore_grok_aarch_tls (bfd *abfd, Elf_Internal_Note *note)
 {
   return elfcore_make_note_pseudosection (abfd, ".reg-aarch-tls", note);
@@ -11274,6 +11280,13 @@ elfcore_grok_note (bfd *abfd, Elf_Internal_Note *note)
       if (note->namesz == 6
 	  && strcmp (note->namedata, "LINUX") == 0)
 	return elfcore_grok_arm_vfp (abfd, note);
+      else
+	return true;
+
+    case NT_ARM_M_SYS:
+      if (note->namesz == 6
+	  && strcmp (note->namedata, "LINUX") == 0)
+	return elfcore_grok_arm_m_system (abfd, note);
       else
 	return true;
 
@@ -12881,6 +12894,18 @@ elfcore_write_arm_vfp (bfd *abfd,
 }
 
 char *
+elfcore_write_arm_m_system (bfd *abfd,
+		       char *buf,
+		       int *bufsiz,
+		       const void *arm_m_sys,
+		       int size)
+{
+  char *note_name = "LINUX";
+  return elfcore_write_note (abfd, buf, bufsiz,
+			     note_name, NT_ARM_M_SYS, arm_m_sys, size);
+}
+
+char *
 elfcore_write_aarch_tls (bfd *abfd,
 		       char *buf,
 		       int *bufsiz,
@@ -13170,6 +13195,8 @@ elfcore_write_register_note (bfd *abfd,
     return elfcore_write_s390_gs_bc (abfd, buf, bufsiz, data, size);
   if (strcmp (section, ".reg-arm-vfp") == 0)
     return elfcore_write_arm_vfp (abfd, buf, bufsiz, data, size);
+  if (strcmp (section, ".reg-arm-m-system") == 0)
+    return elfcore_write_arm_m_system (abfd, buf, bufsiz, data, size);
   if (strcmp (section, ".reg-aarch-tls") == 0)
     return elfcore_write_aarch_tls (abfd, buf, bufsiz, data, size);
   if (strcmp (section, ".reg-aarch-hw-break") == 0)

--- a/include/elf/common.h
+++ b/include/elf/common.h
@@ -740,6 +740,8 @@
 					/*   Note: name must be "LINUX".  */
 #define NT_ARM_ZT       0x40d           /* AArch64 SME2 ZT registers.  */
 					/*   Note: name must be "LINUX".  */
+#define NT_ARM_M_SYS    0x40e           /* ARM M system registers.  */
+					/*   Note: name must be "LINUX".  */
 #define NT_ARC_V2	0x600		/* ARC HS accumulator/extra registers.  */
 					/*   note name must be "LINUX".  */
 #define NT_LARCH_CPUCFG 0xa00		/* LoongArch CPU config registers */


### PR DESCRIPTION
Dirty work to add MSP, PSP register values to coredump.

Note, in order to unwind using PSP correctly, memory at `0xe000ef34` and `0xe000ef38` which is register for `FPCCR` and `FPCAR` should also be included in coredump. 

Otherwise, unwind will report error of `warning: Could not fetch required FPCCR content.  Further unwinding is impossible.
`